### PR TITLE
FIX running postscript on windows.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
     },
     "scripts": {
         "package-states": [
-            "@php vendor/bin/typo3cms install:generatepackagestates"
+            "typo3cms install:generatepackagestates"
         ],
         "folder-structure": [
-            "@php vendor/bin/typo3cms install:fixfolderstructure"
+            "typo3cms install:fixfolderstructure"
         ],
         "pre-deploy": [
             "# Scripts here will be executed by Surf after composer install"


### PR DESCRIPTION
Postscripts are not running on windows. 

> @php vendor/bin/typo3cms install:fixfolderstructure
> 
> dir=$(d=${0%[/\\]*}; cd "$d"; cd "../helhum/typo3-console/Scripts" && pwd)
> 
> \# See if we are running in Cygwin by checking for cygpath program
> if command -v 'cygpath' >/dev/null 2>&1; then
>         \# Cygwin paths start with /cygdrive/ which will break windows PHP,
>         \# so we need to translate the dir path to windows format. However
>         \# we could be using cygwin PHP which does not require this, so we
>         \# test if the path to PHP starts with /cygdrive/ rather than /usr/bin
>         if [[ $(which php) == /cygdrive/* ]]; then
>                 dir=$(cygpath -m "$dir");
>         fi
> fi
> 
> dir=$(echo $dir | sed 's/ /\ /g')
> "${dir}/typo3cms" "$@"


By removing phploader and path to vendor/bin is fixing this issue.