### PR TITLE
Fix order of repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "repositories": [
-        { "type": "composer", "url": "https://composer.typo3.org/" },
-        { "type": "path", "url": "packages/*" }
+        { "type": "path", "url": "packages/*" },
+        { "type": "composer", "url": "https://composer.typo3.org/" }
     ],
     "name": "helhum/typo3-distribution",
     "description" : "TYPO3 CMS Distribution with console and .env support",


### PR DESCRIPTION
If you want to include local repositories in your project, the "path" type needs to be set first. Otherwise a package will be ignored if it also exists in TER or at Packagist.

See https://getcomposer.org/doc/04-schema.md#repositories

> Note: Order is significant here. When looking for a package, Composer will look from the first to the last repository, and pick the first match. By default Packagist is added last which means that custom repositories can override packages from it.
