### PR TITLE
Database Port/Socket ignored when configuration gets loaded

### DIFF
--- a/conf/env.yml
+++ b/conf/env.yml
@@ -7,8 +7,8 @@ DB:
             driver: 'mysqli'
             host: '%env(TYPO3_INSTALL_DB_HOST)%'
             password: '%env(TYPO3_INSTALL_DB_PASSWORD)%'
-            port: ''
-            unix_socket: ''
+            port: '%env(TYPO3_INSTALL_DB_PORT)%'
+            unix_socket: '%env(TYPO3_INSTALL_DB_UNIX_SOCKET)%'
             user: '%env(TYPO3_INSTALL_DB_USER)%'
 GFX:
     processor_path: '%env(TYPO3_GFX_PROCESSOR_PATH)%'


### PR DESCRIPTION
The `conf/env.yml` ignored the environment variables for the databse port/socket.