### PR TITLE
[TASK] Update composer.json license definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     ],
     "name": "helhum/typo3-distribution",
     "description" : "TYPO3 CMS Distribution with console and .env support",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "require": {
         "helhum/typo3-config-handling": "^0.6.1",
         "helhum/typo3-secure-web": "^0.2.7",

--- a/packages/helhum_site_package/composer.json
+++ b/packages/helhum_site_package/composer.json
@@ -2,7 +2,7 @@
     "name": "helhum/site-package",
     "type": "typo3-cms-extension",
     "description" : "An example site package for Helhum TYPO3 Distribution",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.0 <7.3",
         "typo3/cms-core": "^8.7"

--- a/packages/typo3-error-handling/composer.json
+++ b/packages/typo3-error-handling/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "helhum/typo3-error-handling",
     "description" : "Error handling classes for TYPO3 CMS",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.0 <7.3",
         "typo3/cms-core": "^8.7"


### PR DESCRIPTION
Composer license definition GPL-2.0+ has been deprecated
and has to be replaced with GPL-2.0-or-later.